### PR TITLE
Fix namespace for testing classes

### DIFF
--- a/tests/DirectPaymentsTest.php
+++ b/tests/DirectPaymentsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace HPayments\Tests;
+namespace Hpayments\Tests;
 
 use Exception;
 use GuzzleHttp\Exception\GuzzleException;

--- a/tests/LocalIntegrationTest.php
+++ b/tests/LocalIntegrationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace HPayments\Tests;
+namespace Hpayments\Tests;
 
 use Exception;
 use GuzzleHttp\Exception\GuzzleException;


### PR DESCRIPTION
# Changed log

- These classes should be the `Hpayments\Tests` namespace.